### PR TITLE
Implement login/register frontend calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# COSC-4353 Project
+
+This repository contains a React frontend (`/client`) and an Express backend (`/server`).
+
+## Backend setup
+
+1. Install dependencies:
+   ```sh
+   cd server
+   npm install
+   ```
+2. Copy `.env.example` to `.env` and update the values to match your MySQL instance.
+3. Start the server in development mode:
+   ```sh
+   npm run dev
+   ```
+
+The server uses the following environment variables:
+
+- `DB_HOST`
+- `DB_USER`
+- `DB_PASSWORD`
+- `DB_NAME`
+- `PORT` (optional, defaults to `3000`)
+
+## Frontend setup
+
+1. Install dependencies:
+   ```sh
+   cd client
+   npm install
+   ```
+2. Copy `.env.example` to `.env` and update `VITE_API_URL` to point to the backend server.
+3. Start the development server:
+   ```sh
+   npm run dev
+   ```
+
+The frontend reads `VITE_API_URL` when calling the `/register` and `/login` routes.
+
+## Deploying the backend to Vercel
+
+1. Push this repository to GitHub and import it in [Vercel](https://vercel.com/new).
+2. Set the project root to the `server` directory so that Vercel installs dependencies and runs `npm start`.
+3. In the Vercel project settings, add the environment variables listed above under **Environment Variables**.
+4. Deploy the project. Vercel will automatically install dependencies and start your Express server.
+
+Make sure your database is accessible from Vercel and that the credentials are correct.

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3000

--- a/client/pages/LoginPage.jsx
+++ b/client/pages/LoginPage.jsx
@@ -10,16 +10,31 @@ import { Link } from "react-router-dom";
 export default function LoginPage() {
   // Leo Nguyen - login form state
   const [formData, setFormData] = useState({ email: "", password: "" });
+  const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000";
 
   // Leo Nguyen - handle input change
   const handleChange = (e) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
   };
 
-  // Leo Nguyen - placeholder submit handler
-  const handleSubmit = (e) => {
+  // Leo Nguyen - submit handler to call backend
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log("Login submitted", formData);
+    try {
+      const res = await fetch(`${API_URL}/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(formData),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        console.error(data.message);
+      } else {
+        console.log(data.message);
+      }
+    } catch (err) {
+      console.error("Error logging in:", err);
+    }
   };
 
   return (

--- a/client/pages/RegisterPage.jsx
+++ b/client/pages/RegisterPage.jsx
@@ -10,16 +10,39 @@ import { Link } from "react-router-dom";
 export default function RegisterPage() {
   // Leo Nguyen - register form state
   const [formData, setFormData] = useState({ name: "", email: "", password: "", confirm: "" });
+  const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000";
 
   // Leo Nguyen - handle input change
   const handleChange = (e) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
   };
 
-  // Leo Nguyen - placeholder submit handler
-  const handleSubmit = (e) => {
+  // Leo Nguyen - submit handler to call backend
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log("Register submitted", formData);
+    if (formData.password !== formData.confirm) {
+      alert("Passwords do not match");
+      return;
+    }
+    try {
+      const res = await fetch(`${API_URL}/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: formData.name,
+          email: formData.email,
+          password: formData.password,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        console.error(data.message);
+      } else {
+        console.log(data.message);
+      }
+    } catch (err) {
+      console.error("Error registering:", err);
+    }
   };
 
   return (

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,5 @@
+DB_HOST=104.10.143.45
+DB_USER=your_username
+DB_PASSWORD=your_password
+DB_NAME=your_database
+PORT=3000

--- a/server/create_users_table.sql
+++ b/server/create_users_table.sql
@@ -1,0 +1,10 @@
+-- SQL commands to create the user database and table
+CREATE DATABASE IF NOT EXISTS your_database;
+USE your_database;
+
+CREATE TABLE IF NOT EXISTS users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL UNIQUE,
+  password VARCHAR(255) NOT NULL
+);

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,10 @@
   "description": "",
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "mysql2": "^3.10.1",
+    "bcryptjs": "^2.4.3",
+    "dotenv": "^16.3.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/server/server.js
+++ b/server/server.js
@@ -1,11 +1,25 @@
 import express from "express";
 import cors from "cors";
+import mysql from "mysql2/promise";
+import bcrypt from "bcryptjs";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 const app = express();
 const corsOptions = {
   // Origin: This is the frontend URL that will be allowed to access the server.
   origin: ["http://localhost:5173/"],
 };
+
+// Create a connection pool to the MySQL database
+const db = mysql.createPool({
+  host: process.env.DB_HOST || "104.10.143.45",
+  port: 3306,
+  user: process.env.DB_USER || "your_username",
+  password: process.env.DB_PASSWORD || "your_password",
+  database: process.env.DB_NAME || "your_database",
+});
 
 // Allows us to parse JSON data in the request body.
 app.use(express.json());
@@ -16,7 +30,60 @@ app.use(express.urlencoded({ extended: true }));
 // Use the CORS middleware with the specific options we defined.
 app.use(cors(corsOptions));
 
-// Starts the server on port 3000
-app.listen(3000, () => {
-  console.log("Server is running on http://localhost:3000");
+// Register a new user
+app.post("/register", async (req, res) => {
+  const { name, email, password } = req.body;
+  if (!name || !email || !password) {
+    return res
+      .status(400)
+      .json({ message: "name, email and password required" });
+  }
+  try {
+    const [rows] = await db.query("SELECT id FROM users WHERE email = ?", [
+      email,
+    ]);
+    if (rows.length > 0) {
+      return res.status(409).json({ message: "User already exists" });
+    }
+    const hashed = await bcrypt.hash(password, 10);
+    await db.query(
+      "INSERT INTO users (name, email, password) VALUES (?, ?, ?)",
+      [name, email, hashed]
+    );
+    res.status(201).json({ message: "User registered" });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+// Authenticate a user
+app.post("/login", async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ message: "email and password required" });
+  }
+  try {
+    const [rows] = await db.query("SELECT * FROM users WHERE email = ?", [
+      email,
+    ]);
+    if (rows.length === 0) {
+      return res.status(401).json({ message: "Invalid credentials" });
+    }
+    const user = rows[0];
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) {
+      return res.status(401).json({ message: "Invalid credentials" });
+    }
+    res.json({ message: "Login successful" });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+// Starts the server
+app.listen(PORT, () => {
+  console.log(`Server is running on http://localhost:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- call backend /register and /login endpoints in the React forms
- add VITE_API_URL example
- document frontend setup in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68718b3bbcd48326b95708199213303e