### PR TITLE
Implement role-based auth and admin

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3000

--- a/client/components/Navbar.jsx
+++ b/client/components/Navbar.jsx
@@ -1,39 +1,54 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Menu, X, Users } from "lucide-react";
 import { Button } from "./ui/Button";
 import { Link, useLocation } from "react-router-dom";
 
-const devMode = {
-  isLoggedIn: true,
-  isProfileComplete: true,
-};
-
 export default function Navbar({ scrollToSection }) {
   const location = useLocation();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [user, setUser] = useState(() => {
+    const stored = localStorage.getItem("user");
+    return stored ? JSON.parse(stored) : null;
+  });
+
+  useEffect(() => {
+    const handleStorage = () => {
+      const stored = localStorage.getItem("user");
+      setUser(stored ? JSON.parse(stored) : null);
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
 
   const handleScroll = (section) => {
-    scrollToSection(section);
+    if (scrollToSection) {
+      scrollToSection(section);
+    }
     setIsMenuOpen(false);
   };
+
+  const handleLogout = () => {
+    localStorage.removeItem("user");
+    setUser(null);
+    setIsMenuOpen(false);
+  };
+
+  const loggedIn = !!user;
+  const isAdmin = user?.role === "admin";
 
   return (
     <nav className="fixed top-0 left-0 right-0 bg-gray-900/95 backdrop-blur-sm border-b border-gray-800 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
-          {/* Logo */}
           <div className="flex items-center">
             <div className="w-10 h-10 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center">
               <Users className="w-6 h-6 text-white" />
             </div>
-            <span className="ml-3 text-xl font-semibold text-white">
-              Volentra
-            </span>
+            <span className="ml-3 text-xl font-semibold text-white">Volentra</span>
           </div>
 
-          {/* Desktop Navigation */}
           <div className="hidden md:flex items-center space-x-8">
-            {!devMode.isLoggedIn && (
+            {!loggedIn && (
               <>
                 <Link
                   to="/"
@@ -59,7 +74,6 @@ export default function Navbar({ scrollToSection }) {
                 >
                   About
                 </Link>
-                {/* Leo Nguyen - add login and register links */}
                 <Link to="/login">
                   <Button className="text-gray-300 hover:text-blue-400 font-medium transition">
                     Login
@@ -73,93 +87,49 @@ export default function Navbar({ scrollToSection }) {
               </>
             )}
 
-            {devMode.isLoggedIn && !devMode.isProfileComplete && (
+            {loggedIn && (
               <>
-                <Link
-                  to="/"
-                  onClick={(e) => {
-                    if (location.pathname === "/") {
-                      e.preventDefault();
-                      handleScroll("hero");
-                    }
-                  }}
-                  className="text-gray-300 hover:text-blue-400 font-medium transition"
-                >
-                  Home
-                </Link>
-
                 <Link
                   to="/complete-profile"
                   className="text-gray-300 hover:text-blue-400 font-medium transition"
                 >
-                  <Button>Complete Profile</Button>
+                  Profile
                 </Link>
                 <Link
                   to="/event-management"
                   className="text-gray-300 hover:text-blue-400 font-medium transition"
                 >
-                  <Button>Event Management</Button>
+                  Event Management
                 </Link>
-                <Button className="text-gray-300 hover:text-red-400 transition">
-                  Logout
-                </Button>
-              </>
-            )}
-
-            {devMode.isLoggedIn && devMode.isProfileComplete && (
-              <>
-                <Link
-                  to="/"
-                  onClick={(e) => {
-                    if (location.pathname === "/") {
-                      e.preventDefault();
-                      handleScroll("hero");
-                    }
-                  }}
-                  className="text-gray-300 hover:text-blue-400 font-medium transition"
-                >
-                  Home
-                </Link>
-
-                <Link
-                  to="/dashboard"
-                  className="text-gray-300 hover:text-blue-400 font-medium transition"
-                >
-                  Dashboard
-                </Link>
-                <Link
-                  to="/volunteer-history"
-                  className="text-gray-300 hover:text-blue-400 font-medium transition"
-                >
-                  History
-                </Link>
-                <Button className="text-gray-300 hover:text-red-400 transition">
+                {isAdmin && (
+                  <Link
+                    to="/admin"
+                    className="text-gray-300 hover:text-blue-400 font-medium transition"
+                  >
+                    Admin
+                  </Link>
+                )}
+                <Button onClick={handleLogout} className="text-gray-300 hover:text-red-400 transition">
                   Logout
                 </Button>
               </>
             )}
           </div>
 
-          {/* Mobile menu toggle */}
           <div className="md:hidden">
             <button
               onClick={() => setIsMenuOpen(!isMenuOpen)}
               className="text-gray-300 hover:text-blue-400 transition"
             >
-              {isMenuOpen ? (
-                <X className="w-6 h-6" />
-              ) : (
-                <Menu className="w-6 h-6" />
-              )}
+              {isMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
             </button>
           </div>
         </div>
 
-        {/* Mobile Navigation */}
         {isMenuOpen && (
           <div className="md:hidden border-t border-gray-800 bg-gray-900">
             <div className="px-2 pt-2 pb-3 space-y-1">
-              {!devMode.isLoggedIn && location.pathname === "/" && (
+              {!loggedIn && location.pathname === "/" && (
                 <>
                   <button
                     onClick={() => handleScroll("hero")}
@@ -173,101 +143,47 @@ export default function Navbar({ scrollToSection }) {
                   >
                     About
                   </button>
-                  {/* Leo Nguyen - add login and register links */}
                   <Link to="/login">
-                    <Button className="w-full text-blue-400 hover:bg-blue-500/10">
-                      Login
-                    </Button>
+                    <Button className="w-full text-blue-400 hover:bg-blue-500/10">Login</Button>
                   </Link>
                   <Link to="/register">
-                    <Button className="w-full text-blue-400 hover:bg-blue-500/10">
-                      Register
-                    </Button>
+                    <Button className="w-full text-blue-400 hover:bg-blue-500/10">Register</Button>
                   </Link>
                 </>
               )}
 
-              {devMode.isLoggedIn && !devMode.isProfileComplete && (
+              {loggedIn && (
                 <>
-                  <div className="space-y-2">
-                    {/* Left-aligned items */}
-                    <div className="flex flex-col">
-                      <Link
-                        to="/"
-                        onClick={(e) => {
-                          if (location.pathname === "/") {
-                            e.preventDefault();
-                            handleScroll("hero");
-                          }
-                        }}
-                        className="block px-3 py-2 text-gray-300 hover:text-blue-400 hover:bg-gray-800 rounded-md"
-                      >
-                        Home
-                      </Link>
-
-                      <Link
-                        to="/complete-profile"
-                        className="block px-3 py-2 text-gray-300 hover:text-blue-400 hover:bg-gray-800 rounded-md"
-                      >
-                        Complete Profile
-                      </Link>
-                      <Link
-                        to="/event-management"
-                        className="block px-3 py-2 text-gray-300 hover:text-blue-400 hover:bg-gray-800 rounded-md"
-                      >
-                        Event Management Form
-                      </Link>
-                    </div>
-
-                    {/* Centered logout */}
-                    <div className="text-center">
-                      <button className="text-red-400 hover:text-red-400 hover:bg-gray-800 px-3 py-2 rounded-md">
-                        Logout
-                      </button>
-                    </div>
-                  </div>
-                </>
-              )}
-
-              {devMode.isLoggedIn && devMode.isProfileComplete && (
-                <>
-                  <div className="space-y-2">
-                    {/* Left-aligned items */}
-                    <div className="flex flex-col">
-                      <Link
-                        to="/"
-                        onClick={(e) => {
-                          if (location.pathname === "/") {
-                            e.preventDefault();
-                            handleScroll("hero");
-                          }
-                        }}
-                        className="block px-3 py-2 text-gray-300 hover:text-blue-400 hover:bg-gray-800 rounded-md"
-                      >
-                        Home
-                      </Link>
-
-                      <Link
-                        to="/dashboard"
-                        className="block px-3 py-2 text-gray-300 hover:text-blue-400 hover:bg-gray-800 rounded-md"
-                      >
-                        Dashboard
-                      </Link>
-
-                      <Link
-                        to="/volunteer-history"
-                        className="block px-3 py-2 text-gray-300 hover:text-blue-400 hover:bg-gray-800 rounded-md"
-                      >
-                        History
-                      </Link>
-                    </div>
-
-                    {/* Centered logout */}
-                    <div className="text-center">
-                      <button className="text-red-400 hover:text-red-400 hover:bg-gray-800 px-3 py-2 rounded-md">
-                        Logout
-                      </button>
-                    </div>
+                  <Link
+                    to="/complete-profile"
+                    className="block px-3 py-2 text-gray-300 hover:text-blue-400 hover:bg-gray-800 rounded-md"
+                    onClick={() => setIsMenuOpen(false)}
+                  >
+                    Profile
+                  </Link>
+                  <Link
+                    to="/event-management"
+                    className="block px-3 py-2 text-gray-300 hover:text-blue-400 hover:bg-gray-800 rounded-md"
+                    onClick={() => setIsMenuOpen(false)}
+                  >
+                    Event Management
+                  </Link>
+                  {isAdmin && (
+                    <Link
+                      to="/admin"
+                      className="block px-3 py-2 text-gray-300 hover:text-blue-400 hover:bg-gray-800 rounded-md"
+                      onClick={() => setIsMenuOpen(false)}
+                    >
+                      Admin
+                    </Link>
+                  )}
+                  <div className="text-center">
+                    <button
+                      onClick={handleLogout}
+                      className="text-red-400 hover:text-red-400 hover:bg-gray-800 px-3 py-2 rounded-md"
+                    >
+                      Logout
+                    </button>
                   </div>
                 </>
               )}

--- a/client/pages/AdminPage.jsx
+++ b/client/pages/AdminPage.jsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from "react";
+import Layout from "../components/Layout";
+import Navbar from "../components/Navbar";
+import Footer from "../components/Footer";
+import { Button } from "../components/ui/Button";
+
+export default function AdminPage() {
+  const API_URL = import.meta.env.VITE_API_URL || "https://cosc-4353-backend.vercel.app";
+  const [users, setUsers] = useState([]);
+  const [changes, setChanges] = useState({});
+
+  const fetchUsers = async () => {
+    const res = await fetch(`${API_URL}/users`);
+    const data = await res.json();
+    setUsers(data);
+  };
+
+  useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  const handleRole = (id, role) => {
+    setChanges((p) => ({ ...p, [id]: { ...(p[id] || {}), role } }));
+  };
+
+  const handlePassword = (id, password) => {
+    setChanges((p) => ({ ...p, [id]: { ...(p[id] || {}), password } }));
+  };
+
+  const save = async (id) => {
+    const change = changes[id];
+    if (!change) return;
+    if (change.role) {
+      await fetch(`${API_URL}/users/${id}/role`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role: change.role }),
+      });
+    }
+    if (change.password) {
+      await fetch(`${API_URL}/users/${id}/password`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password: change.password }),
+      });
+    }
+    setChanges((p) => ({ ...p, [id]: {} }));
+    fetchUsers();
+  };
+
+  return (
+    <Layout>
+      <Navbar />
+      <div className="pt-24 px-4">
+        <h1 className="text-2xl font-bold mb-4">Manage Users</h1>
+        <table className="w-full text-left">
+          <thead>
+            <tr>
+              <th className="p-2">Name</th>
+              <th className="p-2">Email</th>
+              <th className="p-2">Role</th>
+              <th className="p-2">Change Role</th>
+              <th className="p-2">New Password</th>
+              <th className="p-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((u) => (
+              <tr key={u.id} className="border-t border-gray-700">
+                <td className="p-2">{u.name}</td>
+                <td className="p-2">{u.email}</td>
+                <td className="p-2">{u.role}</td>
+                <td className="p-2">
+                  <select
+                    className="text-black"
+                    value={changes[u.id]?.role || u.role}
+                    onChange={(e) => handleRole(u.id, e.target.value)}
+                  >
+                    <option value="user">user</option>
+                    <option value="admin">admin</option>
+                  </select>
+                </td>
+                <td className="p-2">
+                  <input
+                    type="password"
+                    className="border p-1 text-black"
+                    value={changes[u.id]?.password || ""}
+                    onChange={(e) => handlePassword(u.id, e.target.value)}
+                  />
+                </td>
+                <td className="p-2">
+                  <Button onClick={() => save(u.id)}>Save</Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <Footer />
+    </Layout>
+  );
+}

--- a/client/pages/LoginPage.jsx
+++ b/client/pages/LoginPage.jsx
@@ -5,21 +5,45 @@ import Footer from "../components/Footer";
 import Layout from "../components/Layout";
 import { Button } from "../components/ui/Button";
 // Leo Nguyen - link component for register button
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 export default function LoginPage() {
   // Leo Nguyen - login form state
   const [formData, setFormData] = useState({ email: "", password: "" });
+  const API_URL =
+    import.meta.env.VITE_API_URL || "https://cosc-4353-backend.vercel.app";
+  const navigate = useNavigate();
 
   // Leo Nguyen - handle input change
   const handleChange = (e) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
   };
 
-  // Leo Nguyen - placeholder submit handler
-  const handleSubmit = (e) => {
+  // Leo Nguyen - submit handler to call backend
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log("Login submitted", formData);
+    try {
+      const res = await fetch(`${API_URL}/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(formData),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        console.error(data.message);
+      } else {
+        console.log(data.message);
+        if (data.userId) {
+          localStorage.setItem(
+            "user",
+            JSON.stringify({ id: data.userId, role: data.role })
+          );
+          navigate(data.role === "admin" ? "/admin" : "/");
+        }
+      }
+    } catch (err) {
+      console.error("Error logging in:", err);
+    }
   };
 
   return (

--- a/client/pages/RegisterPage.jsx
+++ b/client/pages/RegisterPage.jsx
@@ -5,21 +5,47 @@ import Footer from "../components/Footer";
 import Layout from "../components/Layout";
 import { Button } from "../components/ui/Button";
 // Leo Nguyen - link component for login button
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 export default function RegisterPage() {
   // Leo Nguyen - register form state
   const [formData, setFormData] = useState({ name: "", email: "", password: "", confirm: "" });
+  const API_URL =
+    import.meta.env.VITE_API_URL || "https://cosc-4353-backend.vercel.app";
+  const navigate = useNavigate();
 
   // Leo Nguyen - handle input change
   const handleChange = (e) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
   };
 
-  // Leo Nguyen - placeholder submit handler
-  const handleSubmit = (e) => {
+  // Leo Nguyen - submit handler to call backend
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log("Register submitted", formData);
+    if (formData.password !== formData.confirm) {
+      alert("Passwords do not match");
+      return;
+    }
+    try {
+      const res = await fetch(`${API_URL}/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: formData.name,
+          email: formData.email,
+          password: formData.password,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        console.error(data.message);
+      } else {
+        console.log(data.message);
+        navigate("/login");
+      }
+    } catch (err) {
+      console.error("Error registering:", err);
+    }
   };
 
   return (

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -12,9 +12,22 @@ import LoginPage from "../pages/LoginPage.jsx";
 import RegisterPage from "../pages/RegisterPage.jsx";
 import VolunteerMatchingForm from "../pages/VolunteerMatchingForm.jsx";
 import EventManagement from "../pages/EventManagement.jsx";
+import AdminPage from "../pages/AdminPage.jsx";
 import "./index.css";
 import VolunteerHistoryPage from "../pages/VolunteerHistoryPage.jsx";
 import ScrollToTop from "../components/CompleteProfile/ScrollToTop.jsx";
+
+function RequireAuth({ children, role }) {
+  const stored = localStorage.getItem("user");
+  const user = stored ? JSON.parse(stored) : null;
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+  if (role && user.role !== role) {
+    return <Navigate to="/" replace />;
+  }
+  return children;
+}
 
 function App() {
   return (
@@ -27,10 +40,46 @@ function App() {
         {/* Leo Nguyen - added login and registration routes */}
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
-        <Route path="/complete-profile" element={<CompleteProfile />} />
-        <Route path="/volunteer" element={<VolunteerMatchingForm />} />
-        <Route path="/volunteer-history" element={<VolunteerHistoryPage />} />
-        <Route path="/event-management" element={<EventManagement />} />
+        <Route
+          path="/complete-profile"
+          element={
+            <RequireAuth>
+              <CompleteProfile />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/volunteer"
+          element={
+            <RequireAuth>
+              <VolunteerMatchingForm />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/volunteer-history"
+          element={
+            <RequireAuth>
+              <VolunteerHistoryPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/event-management"
+          element={
+            <RequireAuth>
+              <EventManagement />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/admin"
+          element={
+            <RequireAuth role="admin">
+              <AdminPage />
+            </RequireAuth>
+          }
+        />
       </Routes>
     </Router>
   );

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,10 @@
   "description": "",
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "mysql2": "^3.10.1",
+    "bcryptjs": "^2.4.3",
+    "dotenv": "^16.3.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS login (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL UNIQUE,
+  password VARCHAR(255) NOT NULL,
+  role ENUM('user','admin') NOT NULL DEFAULT 'user'
+);
+
+CREATE TABLE IF NOT EXISTS profile (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL UNIQUE,
+  location VARCHAR(255),
+  skills VARCHAR(255),
+  preferences TEXT,
+  availability VARCHAR(255),
+  FOREIGN KEY (user_id) REFERENCES login(id) ON DELETE CASCADE
+);

--- a/server/server.js
+++ b/server/server.js
@@ -1,22 +1,188 @@
 import express from "express";
 import cors from "cors";
+import mysql from "mysql2/promise";
+import bcrypt from "bcryptjs";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 const app = express();
 const corsOptions = {
-  // Origin: This is the frontend URL that will be allowed to access the server.
   origin: ["http://localhost:5173/"],
 };
 
-// Allows us to parse JSON data in the request body.
+// Create a connection pool to the MySQL database
+const db = mysql.createPool({
+  host: process.env.DB_HOST || "104.10.143.45",
+  port: 3306,
+  user: process.env.DB_USER || "your_username",
+  password: process.env.DB_PASSWORD || "your_password",
+  database: process.env.DB_NAME || "your_database",
+});
+
 app.use(express.json());
-
-// Allows us to parse URL-encoded data (from HTML forms or URL-style strings). extended allows us to parse nested objects
 app.use(express.urlencoded({ extended: true }));
-
-// Use the CORS middleware with the specific options we defined.
 app.use(cors(corsOptions));
 
-// Starts the server on port 3000
-app.listen(3000, () => {
-  console.log("Server is running on http://localhost:3000");
+function isValidEmail(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+// Register a new user
+app.post("/register", async (req, res) => {
+  const { name, email, password } = req.body;
+  if (
+    typeof name !== "string" ||
+    name.length === 0 ||
+    name.length > 255 ||
+    typeof email !== "string" ||
+    !isValidEmail(email) ||
+    email.length > 255 ||
+    typeof password !== "string" ||
+    password.length < 6 ||
+    password.length > 255
+  ) {
+    return res.status(400).json({ message: "Invalid input" });
+  }
+
+  try {
+    const [rows] = await db.query("SELECT id FROM login WHERE email = ?", [email]);
+    if (rows.length > 0) {
+      return res.status(409).json({ message: "User already exists" });
+    }
+    const hashed = await bcrypt.hash(password, 10);
+    const [result] = await db.query(
+      "INSERT INTO login (name, email, password, role) VALUES (?, ?, ?, 'user')",
+      [name, email, hashed]
+    );
+    await db.query(
+      "INSERT INTO profile (user_id) VALUES (?)",
+      [result.insertId]
+    );
+    res.status(201).json({ message: "User registered" });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Server error" });
+  }
 });
+
+// Authenticate a user
+app.post("/login", async (req, res) => {
+  const { email, password } = req.body;
+  if (
+    typeof email !== "string" ||
+    !isValidEmail(email) ||
+    typeof password !== "string" ||
+    password.length === 0
+  ) {
+    return res.status(400).json({ message: "Invalid input" });
+  }
+
+  try {
+    const [rows] = await db.query("SELECT * FROM login WHERE email = ?", [email]);
+    if (rows.length === 0) {
+      return res.status(401).json({ message: "Invalid credentials" });
+    }
+    const user = rows[0];
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) {
+      return res.status(401).json({ message: "Invalid credentials" });
+    }
+    res.json({ message: "Login successful", userId: user.id, role: user.role });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+// Create or update user profile
+app.post("/profile", async (req, res) => {
+  const { userId, location, skills, preferences, availability } = req.body;
+  if (!userId) {
+    return res.status(400).json({ message: "userId required" });
+  }
+  if (
+    location && location.length > 255 ||
+    skills && skills.length > 255 ||
+    preferences && preferences.length > 1000 ||
+    availability && availability.length > 255
+  ) {
+    return res.status(400).json({ message: "Invalid field lengths" });
+  }
+  try {
+    await db.query(
+      `INSERT INTO profile (user_id, location, skills, preferences, availability)
+       VALUES (?, ?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE location = VALUES(location), skills = VALUES(skills), preferences = VALUES(preferences), availability = VALUES(availability)`,
+      [userId, location || null, skills || null, preferences || null, availability || null]
+    );
+    res.json({ message: "Profile saved" });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+// Retrieve user profile
+app.get("/profile/:userId", async (req, res) => {
+  const { userId } = req.params;
+  try {
+    const [rows] = await db.query(
+      "SELECT user_id, location, skills, preferences, availability FROM profile WHERE user_id = ?",
+      [userId]
+    );
+    if (rows.length === 0) {
+      return res.status(404).json({ message: "Profile not found" });
+    }
+    res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+// Admin: list all users
+app.get("/users", async (req, res) => {
+  try {
+    const [rows] = await db.query("SELECT id, name, email, role FROM login");
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+// Admin: update a user's role
+app.put("/users/:id/role", async (req, res) => {
+  const { id } = req.params;
+  const { role } = req.body;
+  if (!["user", "admin"].includes(role)) {
+    return res.status(400).json({ message: "Invalid role" });
+  }
+  try {
+    await db.query("UPDATE login SET role = ? WHERE id = ?", [role, id]);
+    res.json({ message: "Role updated" });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+// Admin: update a user's password
+app.put("/users/:id/password", async (req, res) => {
+  const { id } = req.params;
+  const { password } = req.body;
+  if (typeof password !== "string" || password.length < 6 || password.length > 255) {
+    return res.status(400).json({ message: "Invalid password" });
+  }
+  try {
+    const hashed = await bcrypt.hash(password, 10);
+    await db.query("UPDATE login SET password = ? WHERE id = ?", [hashed, id]);
+    res.json({ message: "Password updated" });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+export default app;


### PR DESCRIPTION
## Summary
- include role column in SQL schema
- update API to return roles and manage users
- redirect to login after registering
- store user info on login and adjust nav links
- add admin management page and protected routes

## Testing
- `npm test` in `server` *(fails: Error: no test specified)*
- `npm test` in `client` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68718b3bbcd48326b95708199213303e