### PR TITLE
Require completing profile after login

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ The frontend reads `VITE_API_URL` when calling the `/register` and `/login` rout
 
 Make sure your database is accessible from Vercel and that the credentials are correct.
 
+## Database schema
+
+SQL definitions for the `login` and `profile` tables are provided in
+`server/db_schema.sql`. Apply this schema when initializing your MySQL
+database.
+
 ## Deploying the frontend to Vercel
 
 1. Push the contents of the `client` directory to a separate repository or configure a new Vercel project pointing to it.

--- a/client/pages/CompleteProfile.jsx
+++ b/client/pages/CompleteProfile.jsx
@@ -9,10 +9,12 @@ import Preferences from "../components/CompleteProfile/Preferences";
 import { STATES } from "../components/CompleteProfile/STATES";
 import { Button } from "../components/ui/Button";
 import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import Availability from "../components/CompleteProfile/Availability";
 
 export default function CompleteProfile() {
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  const navigate = useNavigate();
 
   const [formData, setFormData] = useState({
     fullName: "",
@@ -129,7 +131,11 @@ export default function CompleteProfile() {
     }
     const payload = {
       userId,
-      location: `${formData.address1} ${formData.address2} ${formData.city} ${formData.state} ${formData.zipCode}`.trim(),
+      address1: formData.address1,
+      address2: formData.address2,
+      city: formData.city,
+      state: formData.state,
+      zipCode: formData.zipCode,
       skills: formData.skills.join(", "),
       preferences: formData.preferences,
       availability: formData.availability.join(", "),
@@ -146,6 +152,8 @@ export default function CompleteProfile() {
       } else {
         console.log(data.message);
         setHasUnsavedChanges(false);
+        localStorage.setItem("profileComplete", "true");
+        navigate("/");
       }
     } catch (err) {
       console.error("Error saving profile:", err);

--- a/client/pages/HomePage.jsx
+++ b/client/pages/HomePage.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Navbar from "../components/Navbar";
 import Hero from "../components/Hero";
 import About from "../components/About";
@@ -7,6 +7,13 @@ import Layout from "../components/Layout";
 
 export default function HomePage() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [notifications, setNotifications] = useState([]);
+
+  useEffect(() => {
+    if (localStorage.getItem("profileComplete") === "false") {
+      setNotifications(["Please complete your profile"]);
+    }
+  }, []);
 
   const scrollToSection = (sectionId) => {
     const element = document.getElementById(sectionId);
@@ -17,8 +24,7 @@ export default function HomePage() {
   };
 //test Notification Center
   return (
-    //<Layout notifications={["✅ Event Assigned", "📢 Profile updated"]}>
-    <Layout>
+    <Layout notifications={notifications}>
       <Navbar scrollToSection={scrollToSection} />
       <Hero scrollToSection={scrollToSection} />
       <About />

--- a/client/pages/LoginPage.jsx
+++ b/client/pages/LoginPage.jsx
@@ -30,8 +30,16 @@ export default function LoginPage() {
       } else {
         toast.success("Login successful");
         if (data.userId) {
-          localStorage.setItem("user", JSON.stringify({ id: data.userId, role: data.role }));
-          navigate("/");
+          localStorage.setItem("userId", data.userId);
+          localStorage.setItem(
+            "profileComplete",
+            data.profileComplete ? "true" : "false"
+          );
+          if (data.profileComplete) {
+            navigate("/");
+          } else {
+            navigate("/complete-profile");
+          }
         }
       }
     } catch (err) {

--- a/server/db_schema.sql
+++ b/server/db_schema.sql
@@ -1,0 +1,22 @@
+CREATE TABLE login (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    role ENUM('user','admin') DEFAULT 'user'
+);
+
+CREATE TABLE profile (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL UNIQUE,
+    address1 VARCHAR(100),
+    address2 VARCHAR(100),
+    city VARCHAR(100),
+    state VARCHAR(50),
+    zip_code VARCHAR(10),
+    skills VARCHAR(255),
+    preferences TEXT,
+    availability VARCHAR(255),
+    is_complete TINYINT(1) DEFAULT 0,
+    FOREIGN KEY (user_id) REFERENCES login(id)
+);

--- a/server/server.js
+++ b/server/server.js
@@ -105,7 +105,13 @@ app.post("/login", async (req, res) => {
         const ok = await bcrypt.compare(password, user.password);
         if (!ok) return res.status(401).json({ message: "Invalid credentials" });
 
-        res.json({ message: "Login successful", userId: user.id });
+        const [profileRows] = await db.query(
+            "SELECT is_complete FROM profile WHERE user_id = ?",
+            [user.id]
+        );
+        const profileComplete = profileRows.length && profileRows[0].is_complete === 1;
+
+        res.json({ message: "Login successful", userId: user.id, profileComplete });
     } catch (err) {
         console.error("Login error:", err);
         res.status(500).json({ message: "Server error" });
@@ -114,29 +120,58 @@ app.post("/login", async (req, res) => {
 
 // Create / update profile
 app.post("/profile", async (req, res) => {
-    const { userId, location, skills, preferences, availability } = req.body;
+    const {
+        userId,
+        address1,
+        address2,
+        city,
+        state,
+        zipCode,
+        skills,
+        preferences,
+        availability,
+    } = req.body;
     if (!userId)
         return res.status(400).json({ message: "userId required" });
 
     if (
-        (location     && location.length     > 255) ||
-        (skills       && skills.length       > 255) ||
-        (preferences  && preferences.length  > 1000)||
-        (availability && availability.length > 255)
+        (address1    && address1.length    > 100) ||
+        (address2    && address2.length    > 100) ||
+        (city        && city.length        > 100) ||
+        (state       && state.length       > 50)  ||
+        (zipCode     && zipCode.length     > 10)  ||
+        (skills      && skills.length      > 255) ||
+        (preferences && preferences.length > 1000)||
+        (availability&& availability.length> 255)
     ) {
         return res.status(400).json({ message: "Invalid field lengths" });
     }
 
     try {
         await db.query(
-            `INSERT INTO profile (user_id, location, skills, preferences, availability)
-         VALUES (?, ?, ?, ?, ?)
+            `INSERT INTO profile (user_id, address1, address2, city, state, zip_code, skills, preferences, availability, is_complete)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
            ON DUPLICATE KEY UPDATE
-                              location     = VALUES(location),
+                              address1     = VALUES(address1),
+                              address2     = VALUES(address2),
+                              city         = VALUES(city),
+                              state        = VALUES(state),
+                              zip_code     = VALUES(zip_code),
                               skills       = VALUES(skills),
                               preferences  = VALUES(preferences),
-                              availability = VALUES(availability)`,
-            [userId, location || null, skills || null, preferences || null, availability || null]
+                              availability = VALUES(availability),
+                              is_complete  = 1`,
+            [
+                userId,
+                address1 || null,
+                address2 || null,
+                city || null,
+                state || null,
+                zipCode || null,
+                skills || null,
+                preferences || null,
+                availability || null,
+            ]
         );
         res.json({ message: "Profile saved" });
     } catch (err) {
@@ -149,7 +184,8 @@ app.post("/profile", async (req, res) => {
 app.get("/profile/:userId", async (req, res) => {
     try {
         const [rows] = await db.query(
-            "SELECT user_id, location, skills, preferences, availability FROM profile WHERE user_id = ?",
+            `SELECT user_id, address1, address2, city, state, zip_code, skills, preferences, availability, is_complete
+             FROM profile WHERE user_id = ?`,
             [req.params.userId]
         );
         if (!rows.length) return res.status(404).json({ message: "Profile not found" });


### PR DESCRIPTION
## Summary
- add MySQL table definitions
- return profile completion status on login
- store address details and completion flag when saving profiles
- show reminder notification if profile incomplete
- redirect to profile page until it's completed
- document where schema SQL lives

## Testing
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_6875d1d994608326bd13158880ae6d6c