### PR TITLE
Link skills to table and include full name

### DIFF
--- a/client/pages/CompleteProfile.jsx
+++ b/client/pages/CompleteProfile.jsx
@@ -44,25 +44,16 @@ export default function CompleteProfile() {
   const [selectedDate, setSelectedDate] = useState("");
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
-  // Hard-coded skill options for now. Replace with API later if needed.
-  const skillOptions = [
-    "Teaching & Education",
-    "Healthcare & Medical",
-    "Technology & IT",
-    "Construction & Manual Labor",
-    "Event Planning",
-    "Marketing & Communications",
-    "Food Service & Preparation",
-    "Administrative Support",
-    "Childcare & Youth Programs",
-    "Senior Care",
-    "Environmental & Conservation",
-    "Arts & Creative",
-    "Legal & Advocacy",
-    "Transportation",
-    "Language Translation",
-    "Financial & Accounting",
-  ];
+  const [skillOptions, setSkillOptions] = useState([]);
+
+  useEffect(() => {
+    fetch(`${API_URL}/skills`)
+        .then((res) => (res.ok ? res.json() : []))
+        .then((data) => {
+          if (Array.isArray(data)) setSkillOptions(data);
+        })
+        .catch(() => {});
+  }, [API_URL]);
 
   // Track unsaved change state
   useEffect(() => {
@@ -114,7 +105,11 @@ export default function CompleteProfile() {
             city: data.city ?? "",
             state: data.state ?? "",
             zipCode: data.zipCode ?? data.zip_code ?? "",
-            skills: data.skills ? data.skills.split(/,\s*/) : [],
+            skills: Array.isArray(data.skills)
+                ? data.skills
+                : data.skills
+                    ? data.skills.split(/,\s*/)
+                    : [],
             preferences: data.preferences ?? "",
             availability: data.availability ? data.availability.split(/,\s*/) : [],
           }));

--- a/server/db_schema.sql
+++ b/server/db_schema.sql
@@ -1,6 +1,6 @@
 CREATE TABLE login (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(255) NOT NULL,
+    full_name VARCHAR(255) NOT NULL,
     email VARCHAR(255) NOT NULL UNIQUE,
     password VARCHAR(255) NOT NULL,
     role ENUM('user','admin') DEFAULT 'user'
@@ -14,11 +14,23 @@ CREATE TABLE profile (
     city VARCHAR(100),
     state VARCHAR(50),
     zip_code VARCHAR(10),
-    skills VARCHAR(255),
     preferences TEXT,
     availability VARCHAR(255),
     is_complete TINYINT(1) DEFAULT 0,
     FOREIGN KEY (user_id) REFERENCES login(id)
+);
+
+CREATE TABLE skill (
+    skill_id INT AUTO_INCREMENT PRIMARY KEY,
+    skill_name VARCHAR(100) NOT NULL UNIQUE
+);
+
+CREATE TABLE profile_skill (
+    user_id INT NOT NULL,
+    skill_id INT NOT NULL,
+    PRIMARY KEY (user_id, skill_id),
+    FOREIGN KEY (user_id) REFERENCES profile(user_id),
+    FOREIGN KEY (skill_id) REFERENCES skill(skill_id)
 );
 
 CREATE TABLE states (

--- a/server/server.js
+++ b/server/server.js
@@ -77,11 +77,12 @@ app.use("/history", historyRoutes);
 
 // Register
 app.post("/register", async (req, res) => {
-  const { name, email, password } = req.body;
+  const { fullName, name, email, password } = req.body;
+  const finalName = fullName || name;
   if (
-    typeof name !== "string" ||
-    !name.trim() ||
-    name.length > 255 ||
+    typeof finalName !== "string" ||
+    !finalName.trim() ||
+    finalName.length > 255 ||
     typeof email !== "string" ||
     !isValidEmail(email) ||
     email.length > 255 ||
@@ -93,7 +94,7 @@ app.post("/register", async (req, res) => {
   }
 
   try {
-    console.log("Register attempt:", { name, email });
+    console.log("Register attempt:", { name: finalName, email });
 
     const [dup] = await db.query("SELECT id FROM login WHERE email = ?", [
       email,
@@ -103,8 +104,8 @@ app.post("/register", async (req, res) => {
 
     const hashed = await bcrypt.hash(password, 10);
     const [result] = await db.query(
-      "INSERT INTO login (name, email, password) VALUES (?, ?, ?)",
-      [name, email, hashed]
+      "INSERT INTO login (full_name, email, password) VALUES (?, ?, ?)",
+      [finalName, email, hashed]
     );
     await db.query("INSERT INTO profile (user_id) VALUES (?)", [
       result.insertId,
@@ -153,6 +154,7 @@ app.post("/login", async (req, res) => {
       userId: user.id,
       role: user.role,
       profileComplete,
+      fullName: user.full_name ?? user.name ?? null,
     });
   } catch (err) {
     console.error("Login error:", err);
@@ -164,6 +166,7 @@ app.post("/login", async (req, res) => {
 app.post("/profile", async (req, res) => {
   const {
     userId,
+    fullName,
     address1,
     address2,
     city,
@@ -190,15 +193,14 @@ app.post("/profile", async (req, res) => {
 
   try {
     await db.query(
-      `INSERT INTO profile (user_id, address1, address2, city, state, zip_code, skills, preferences, availability, is_complete)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+      `INSERT INTO profile (user_id, address1, address2, city, state, zip_code, preferences, availability, is_complete)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)
            ON DUPLICATE KEY UPDATE
                               address1     = VALUES(address1),
                               address2     = VALUES(address2),
                               city         = VALUES(city),
                               state        = VALUES(state),
                               zip_code     = VALUES(zip_code),
-                              skills       = VALUES(skills),
                               preferences  = VALUES(preferences),
                               availability = VALUES(availability),
                               is_complete  = 1`,
@@ -209,11 +211,31 @@ app.post("/profile", async (req, res) => {
         city || null,
         state || null,
         zipCode || null,
-        skills || null,
         preferences || null,
         availability || null,
       ]
     );
+
+    if (fullName) {
+      await db.query("UPDATE login SET full_name = ? WHERE id = ?", [fullName, userId]);
+    }
+
+    await db.query("DELETE FROM profile_skill WHERE user_id = ?", [userId]);
+    const skillNames = Array.isArray(skills)
+        ? skills
+        : (skills || "").split(/,\s*/).filter((s) => s);
+    for (const name of skillNames) {
+      let [rows] = await db.query("SELECT skill_id FROM skill WHERE skill_name = ?", [name]);
+      let sid;
+      if (rows.length) {
+        sid = rows[0].skill_id;
+      } else {
+        const [res2] = await db.query("INSERT INTO skill (skill_name) VALUES (?)", [name]);
+        sid = res2.insertId;
+      }
+      await db.query("INSERT INTO profile_skill (user_id, skill_id) VALUES (?, ?)", [userId, sid]);
+    }
+
     res.json({ message: "Profile saved" });
   } catch (err) {
     console.error("Profile save error:", err);
@@ -225,15 +247,58 @@ app.post("/profile", async (req, res) => {
 app.get("/profile/:userId", async (req, res) => {
   try {
     const [rows] = await db.query(
-      `SELECT user_id, address1, address2, city, state, zip_code, skills, preferences, availability, is_complete
-             FROM profile WHERE user_id = ?`,
+      `SELECT p.user_id,
+              l.full_name,
+              p.address1,
+              p.address2,
+              p.city,
+              p.state,
+              p.zip_code,
+              GROUP_CONCAT(s.skill_name ORDER BY s.skill_name) AS skills,
+              p.preferences,
+              p.availability,
+              p.is_complete
+         FROM profile p
+         JOIN login l ON l.id = p.user_id
+         LEFT JOIN profile_skill ps ON ps.user_id = p.user_id
+         LEFT JOIN skill s ON s.skill_id = ps.skill_id
+        WHERE p.user_id = ?
+        GROUP BY p.user_id`,
       [req.params.userId]
     );
     if (!rows.length)
       return res.status(404).json({ message: "Profile not found" });
-    res.json(rows[0]);
+    const row = rows[0];
+    const skills = row.skills ? row.skills.split(/,\s*/) : [];
+    res.json({
+      user_id: row.user_id,
+      fullName: row.full_name,
+      address1: row.address1,
+      address2: row.address2,
+      city: row.city,
+      state: row.state,
+      zipCode: row.zip_code,
+      skills,
+      preferences: row.preferences,
+      availability: row.availability,
+      is_complete: row.is_complete,
+    });
   } catch (err) {
     console.error("Profile fetch error:", err);
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+// List all skills
+app.get("/skills", async (_req, res) => {
+  try {
+    const [rows] = await db.query(
+      "SELECT skill_name FROM skill ORDER BY skill_name"
+    );
+    const names = rows.map(r => r.skill_name);
+    res.json(names);
+  } catch (err) {
+    console.error("Skills fetch error:", err);
     res.status(500).json({ message: "Server error" });
   }
 });


### PR DESCRIPTION
## Summary
- normalize schema with `full_name` field and add `skill` & `profile_skill` tables
- update server routes to store skills via join table
- expose full name on login and profile retrieval
- provide `/skills` endpoint
- load skills from API on profile page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d0f8338e083269778c4f5c80b57bb