### PR TITLE
Implement calendar API and UI

### DIFF
--- a/client/components/VolunteerDashboard/Calendar.jsx
+++ b/client/components/VolunteerDashboard/Calendar.jsx
@@ -3,6 +3,7 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 
 export const CalendarView = ({ upcomingEvents, allEvents }) => {
   const [currentMonth, setCurrentMonth] = useState(new Date());
+  const [selectedEvent, setSelectedEvent] = useState(null);
 
   const daysInMonth = new Date(
     currentMonth.getFullYear(),
@@ -63,6 +64,7 @@ export const CalendarView = ({ upcomingEvents, allEvents }) => {
       days.push(
         <div
           key={day}
+          onClick={() => event && setSelectedEvent(event.details || event)}
           className={`h-10 md:h-14 flex flex-col items-center justify-center rounded-lg ${
             event
               ? "bg-indigo-800 hover:bg-indigo-700 cursor-pointer"
@@ -128,6 +130,28 @@ export const CalendarView = ({ upcomingEvents, allEvents }) => {
           </div>
         ))}
       </div>
+      {selectedEvent && (
+        <div className="fixed inset-0 bg-black/30 backdrop-blur-sm flex justify-center items-center z-50">
+          <div className="bg-[#1a2035] text-white rounded-xl p-6 w-[90%] max-w-md relative shadow-lg">
+            <button
+              onClick={() => setSelectedEvent(null)}
+              className="absolute top-3 right-3 text-gray-400 hover:text-red-400"
+            >
+              &times;
+            </button>
+            <h3 className="text-2xl font-semibold text-indigo-400 mb-4">
+              {selectedEvent.event_name || selectedEvent.title}
+            </h3>
+            <p className="text-sm mb-2">{selectedEvent.event_description}</p>
+            <p className="text-sm">
+              {new Date(selectedEvent.start_time || selectedEvent.date).toLocaleString()}
+            </p>
+            {selectedEvent.event_location && (
+              <p className="text-sm mt-1">{selectedEvent.event_location}</p>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/client/pages/VolunteerDashboard.jsx
+++ b/client/pages/VolunteerDashboard.jsx
@@ -43,27 +43,28 @@ export default function VolunteerDashboard() {
     },
   ];
 
-  const upcomingEvents = [
-    {
-      date: new Date(2025, 7, 15),
-      title: "Community Food Drive",
-    },
-  ];
-
-  const allEvents = [
-    {
-      date: new Date(2025, 7, 15),
-      title: "Community Food Drive",
-    },
-    {
-      date: new Date(2024, 11, 22),
-      title: "Senior Care Visit",
-    },
-  ];
+  const [upcomingEvents, setUpcomingEvents] = useState([]);
+  const [allEvents, setAllEvents] = useState([]);
 
   const API_URL = import.meta.env.VITE_API_URL;
 
   const [nextEvent, setNextEvent] = useState({});
+
+  const fetchEvents = async () => {
+    try {
+      const response = await axios.get(`${API_URL}/events`);
+      const events = response.data.events.map((e) => ({
+        date: new Date(e.start_time),
+        title: e.event_name,
+        details: e,
+      }));
+      setAllEvents(events);
+      const upcoming = events.filter((e) => e.date >= new Date());
+      setUpcomingEvents(upcoming);
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   const getNextEvent = async () => {
     try {
@@ -78,6 +79,7 @@ export default function VolunteerDashboard() {
 
   useEffect(() => {
     getNextEvent();
+    fetchEvents();
   }, []);
 
   return (

--- a/server/controllers/eventController.js
+++ b/server/controllers/eventController.js
@@ -1,8 +1,22 @@
+import { query } from "../db.js";
+
 export let events = [];
 
 export function createEvent(eventData) {
   events.push(eventData);
   return eventData;
+}
+
+export async function getEvents(req, res) {
+  try {
+    const sql =
+      "SELECT event_id, event_name, event_description, event_location, urgency, start_time, end_time FROM eventManage";
+    const events = await query(sql);
+    res.json({ events });
+  } catch (err) {
+    console.error("Error fetching events", err.message);
+    res.status(500).json({ message: "Error fetching events" });
+  }
 }
 
 export function resetEvents() {

--- a/server/routes/eventRoutes.js
+++ b/server/routes/eventRoutes.js
@@ -1,5 +1,5 @@
 import express from "express";
-import { createEvent } from "../controllers/eventController.js";
+import { createEvent, getEvents } from "../controllers/eventController.js";
 
 const router = express.Router();
 
@@ -11,6 +11,9 @@ router.use((req, res, next) => {
   console.log(`Incoming ${req.method} request to ${req.url}`);
   next();
 });
+
+// GET route to fetch events from database
+router.get("/events", getEvents);
 
 // POST route to create a new event
 router.post("/events", (req, res) => {

--- a/server/tests/eventController.test.js
+++ b/server/tests/eventController.test.js
@@ -1,26 +1,39 @@
-import {
-  createEvent,
-  events,
-  resetEvents,
-} from "../controllers/eventController.js";
+import { jest } from '@jest/globals';
 
-describe("createEvent", () => {
+jest.unstable_mockModule('../db.js', () => ({
+  query: jest.fn(),
+}));
+
+const { createEvent, events, resetEvents, getEvents } = await import('../controllers/eventController.js');
+const { query } = await import('../db.js');
+
+describe('createEvent', () => {
   beforeEach(() => {
-    resetEvents(); // ensure clean slate before each test
+    resetEvents();
   });
 
-  test("should add a new event to the events array", () => {
-    const eventData = { eventName: "Birthday Party" };
-    createEvent(eventData);
-
-    expect(events.length).toBe(1);
-    expect(events[0]).toEqual(eventData);
-  });
-
-  test("should return the created event data", () => {
-    const eventData = { eventName: "Graduation" };
+  test('should add and return new event', () => {
+    const eventData = { eventName: 'Birthday Party' };
     const result = createEvent(eventData);
-
     expect(result).toEqual(eventData);
+  });
+});
+
+describe('getEvents', () => {
+  test('returns events from database', async () => {
+    query.mockResolvedValue([{ event_id: 1 }]);
+    const req = {};
+    const res = { json: jest.fn() };
+    await getEvents(req, res);
+    expect(query).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ events: [{ event_id: 1 }] });
+  });
+
+  test('handles errors', async () => {
+    query.mockRejectedValue(new Error('fail'));
+    const req = {};
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    await getEvents(req, res);
+    expect(res.status).toHaveBeenCalledWith(500);
   });
 });


### PR DESCRIPTION
## Summary
- add `getEvents` controller and GET /events route
- fetch events for volunteer dashboard calendar and show details on click
- add interactive calendar modal and fetch events from backend
- test event fetching logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d5a7616c48326bc63b406bbe94a9c