### PR TITLE
feat: add admin event report page

### DIFF
--- a/client/components/Navbar.jsx
+++ b/client/components/Navbar.jsx
@@ -132,6 +132,12 @@ export default function Navbar({ scrollToSection }) {
                     >
                       Manage Users
                     </Link>
+                    <Link
+                      to="/admin/event-report"
+                      className="text-gray-300 hover:text-blue-400 font-medium transition"
+                    >
+                      Reports
+                    </Link>
                   </>
                 )}
                 <Button onClick={handleLogout} className="text-gray-300 hover:text-red-400 transition">
@@ -217,6 +223,13 @@ export default function Navbar({ scrollToSection }) {
                         onClick={() => setIsMenuOpen(false)}
                       >
                         Manage Users
+                      </Link>
+                      <Link
+                        to="/admin/event-report"
+                        className="block px-3 py-2 text-gray-300 hover:text-blue-400 hover:bg-gray-800 rounded-md"
+                        onClick={() => setIsMenuOpen(false)}
+                      >
+                        Reports
                       </Link>
                     </>
                   )}

--- a/client/pages/AdminEventReport.jsx
+++ b/client/pages/AdminEventReport.jsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import Layout from "../components/Layout";
+import Navbar from "../components/Navbar";
+import Footer from "../components/Footer";
+
+export default function AdminEventReport() {
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const API_URL = "https://cosc-4353-backend.vercel.app";
+
+  useEffect(() => {
+    const fetchEvents = async () => {
+      try {
+        const { data } = await axios.get(`${API_URL}/events`);
+        const list = Array.isArray(data?.events) ? data.events : [];
+        setEvents(list);
+      } catch (err) {
+        console.error("AdminEventReport fetchEvents error:", err);
+        setError("Failed to load events");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchEvents();
+  }, []);
+
+  const exportCSV = () => {
+    const headers = ["Event Name", "Location", "Start Time", "End Time"];
+    const rows = events.map((e) => [
+      e.event_name,
+      e.event_location,
+      e.start_time,
+      e.end_time,
+    ]);
+    const csvContent = [headers, ...rows]
+      .map((r) => r.map((v) => `"${v ?? ""}"`).join(","))
+      .join("\n");
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.setAttribute("href", url);
+    link.setAttribute("download", "event-report.csv");
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  return (
+    <Layout>
+      <Navbar />
+      <div className="pt-24 px-4">
+        <h1 className="text-2xl font-bold mb-4">Event Report</h1>
+        {loading ? (
+          <p>Loading...</p>
+        ) : error ? (
+          <p className="text-red-500">{error}</p>
+        ) : (
+          <>
+            <button
+              onClick={exportCSV}
+              className="mb-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            >
+              Export CSV
+            </button>
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-700">
+                <thead>
+                  <tr>
+                    <th className="px-4 py-2 text-left">Event</th>
+                    <th className="px-4 py-2 text-left">Location</th>
+                    <th className="px-4 py-2 text-left">Start</th>
+                    <th className="px-4 py-2 text-left">End</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-700">
+                  {events.map((ev) => (
+                    <tr key={ev.event_id}>
+                      <td className="px-4 py-2">{ev.event_name}</td>
+                      <td className="px-4 py-2">{ev.event_location}</td>
+                      <td className="px-4 py-2">{ev.start_time}</td>
+                      <td className="px-4 py-2">{ev.end_time}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </div>
+      <Footer />
+    </Layout>
+  );
+}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -14,6 +14,7 @@ import ManageUsers from "../pages/ManageUsers.jsx";
 import VolunteerHistoryPage from "../pages/VolunteerHistoryPage.jsx";
 import ScrollToTop from "../components/CompleteProfile/ScrollToTop.jsx";
 import VolunteerDashboard from "../pages/VolunteerDashboard.jsx";
+import AdminEventReport from "../pages/AdminEventReport.jsx";
 import "./index.css";
 
 function RequireAuth({ children, role }) {
@@ -93,6 +94,14 @@ export default function App() {
                         element={
                             <RequireAuth role="admin">
                                 <VolunteerDashboard />
+                            </RequireAuth>
+                        }
+                    />
+                    <Route
+                        path="/admin/event-report"
+                        element={
+                            <RequireAuth role="admin">
+                                <AdminEventReport />
                             </RequireAuth>
                         }
                     />


### PR DESCRIPTION
## Summary
- add admin event report page to list events and export CSV
- wire up admin report route
- link reports in navigation

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68944941e62c83268f218e53028da20f