### PR TITLE
Add basic client and server route tests

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.2.0",
     "jest-environment-jsdom": "^30.0.5",
-    "vite": "^7.0.0"
+    "vite": "^7.0.0",
+    "jest": "^30.0.5"
   }
 }

--- a/client/tests/LoadingSpinner.test.jsx
+++ b/client/tests/LoadingSpinner.test.jsx
@@ -1,0 +1,20 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { LoadingSpinner } from '../components/LoadingSpinner.jsx';
+
+describe('LoadingSpinner', () => {
+  test('renders with provided text', () => {
+    render(React.createElement(LoadingSpinner, { text: 'Loading...' }));
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  test('fullScreen prop adds overlay', () => {
+    const { container } = render(
+      React.createElement(LoadingSpinner, { text: 'Please wait', fullScreen: true })
+    );
+    expect(container.firstChild).toHaveClass('fixed');
+    expect(screen.getByText('Please wait')).toBeInTheDocument();
+  });
+});

--- a/server/tests/notificationsRoutes.test.js
+++ b/server/tests/notificationsRoutes.test.js
@@ -1,0 +1,39 @@
+import request from "supertest";
+import express from "express";
+import { jest } from "@jest/globals";
+
+// Re-import router fresh for each test to reset in-memory data
+let app;
+beforeEach(async () => {
+  jest.resetModules();
+  const router = (await import("../routes/notifications.js")).default;
+  app = express();
+  app.use(express.json());
+  app.use("/notifications", router);
+});
+
+describe("notifications routes", () => {
+  test("GET /notifications returns array", async () => {
+    const res = await request(app).get("/notifications");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  test("POST /notifications creates notification", async () => {
+    const res = await request(app)
+      .post("/notifications")
+      .send({ userId: 99, message: "hello" });
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ userId: 99, message: "hello", read: false });
+  });
+
+  test("GET /notifications/:userId filters by user", async () => {
+    await request(app)
+      .post("/notifications")
+      .send({ userId: 123, message: "test" });
+    const res = await request(app).get("/notifications/123");
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBeGreaterThan(0);
+    expect(res.body.every((n) => n.userId === 123)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest to client dev dependencies
- add LoadingSpinner component tests
- test notifications router endpoints

## Testing
- `npm test --prefix server -- tests/notificationsRoutes.test.js`
- `node --experimental-vm-modules node_modules/jest/bin/jest.js` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68964e9f65188326bb5194da410ab22d