### PR TITLE
Add root package.json for Vercel deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ This repository contains the React front-end for the COSC-4353 project. The back
 ## Build
 
 Run `npm run build` to create the production-ready files in `client/dist/`.
+
+## Deployment
+
+The included `vercel.json` file tells Vercel to run `npm run build` and serve the output from `client/dist`.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ This repository contains the React front-end for the COSC-4353 project. The back
 
 1. Install dependencies:
    ```sh
-   cd client
    npm install
    ```
-2. Copy `.env.example` to `.env` and adjust `VITE_API_URL` if needed.
+   The root `package.json` installs the client dependencies automatically.
+2. Copy `.env.example` to `.env` inside `client` and adjust `VITE_API_URL` if needed.
 3. Start the development server:
    ```sh
    npm run dev
@@ -17,4 +17,4 @@ This repository contains the React front-end for the COSC-4353 project. The back
 
 ## Build
 
-Run `npm run build` inside `client` to create the production-ready files in `dist/`.
+Run `npm run build` to create the production-ready files in `client/dist/`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "cosc-4353-project",
+  "private": true,
+  "scripts": {
+    "postinstall": "npm install --prefix client",
+    "dev": "npm run dev --prefix client",
+    "build": "npm run build --prefix client",
+    "preview": "npm run preview --prefix client"
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "client/dist"
+}


### PR DESCRIPTION
## Summary
- add root `package.json` with scripts to build and run the client
- document root-level commands for installing deps and building
- ignore build artifacts

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a241a9896c83269c00d10534bfc0ec