### PR TITLE
Handle varied backend login response fields

### DIFF
--- a/client/pages/AdminDemo.jsx
+++ b/client/pages/AdminDemo.jsx
@@ -1,0 +1,22 @@
+import Layout from "../components/Layout";
+import Navbar from "../components/Navbar";
+import Footer from "../components/Footer";
+import CalendarView from "../components/AdminDashboard/AdminCalendar.jsx";
+
+const demoEvents = [
+  { date: new Date("2025-06-15T09:00:00"), title: "Park Cleanup", details: {} },
+  { date: new Date("2025-06-20T10:00:00"), title: "Food Drive", details: {} },
+];
+
+export default function AdminDemo() {
+  return (
+    <Layout>
+      <Navbar />
+      <div className="pt-24 px-4">
+        <h1 className="text-2xl font-bold mb-4">Admin Dashboard (Demo)</h1>
+        <CalendarView allEvents={demoEvents} currentUserId={1} refreshEvents={() => {}} />
+      </div>
+      <Footer />
+    </Layout>
+  );
+}

--- a/client/pages/LoginPage.jsx
+++ b/client/pages/LoginPage.jsx
@@ -19,6 +19,18 @@ export default function LoginPage() {
     handleSubmit,
     formState: { errors },
   } = useForm({ defaultValues: { email: "", password: "" } });
+  const demoLogin = (role) => {
+    const demoUser =
+      role === "admin"
+        ? { id: 1, role: "admin", fullName: "Demo Admin" }
+        : { id: 2, role: "volunteer", fullName: "Demo Volunteer" };
+    localStorage.setItem("user", JSON.stringify(demoUser));
+    localStorage.setItem("userId", String(demoUser.id));
+    localStorage.setItem("fullName", demoUser.fullName);
+    localStorage.setItem("profileComplete", "true");
+    localStorage.setItem("isLoggedIn", "true");
+    navigate(role === "admin" ? "/admin-demo" : "/volunteer-demo");
+  };
 
   const onSubmit = async (formData) => {
     setLoading(true);
@@ -43,20 +55,22 @@ export default function LoginPage() {
 
       toast.success("Login successful");
 
-      // Persist session info
-      if (data.userId) {
-        const fullName =
-            data.fullName ?? data.full_name ?? data.name ?? null;
+      // Persist session info (handle various backend field names)
+      const userId = data.userId ?? data.user_id ?? data.id;
+      const fullName = data.fullName ?? data.full_name ?? data.name ?? null;
+      const profileComplete =
+          data.profileComplete ?? data.profile_complete ?? false;
 
+      if (userId) {
         localStorage.setItem(
             "user",
-            JSON.stringify({ id: data.userId, role: data.role, fullName })
+            JSON.stringify({ id: userId, role: data.role, fullName })
         );
-        localStorage.setItem("userId", String(data.userId));
+        localStorage.setItem("userId", String(userId));
         if (fullName) localStorage.setItem("fullName", fullName);
         localStorage.setItem(
             "profileComplete",
-            data.profileComplete ? "true" : "false"
+            profileComplete ? "true" : "false"
         );
         localStorage.setItem("isLoggedIn", "true");
       }
@@ -160,6 +174,23 @@ export default function LoginPage() {
                   Need an account? Register
                 </Button>
               </Link>
+            </div>
+            <div className="text-center mt-6">
+              <p className="text-gray-400 mb-2">Or try a demo</p>
+              <div className="flex justify-center gap-4">
+                <Button
+                  onClick={() => demoLogin("admin")}
+                  className="bg-gradient-to-r from-amber-600 to-pink-600 hover:from-amber-700 hover:to-pink-700 text-white py-2 px-4 rounded-xl"
+                >
+                  Demo Admin
+                </Button>
+                <Button
+                  onClick={() => demoLogin("volunteer")}
+                  className="bg-gradient-to-r from-green-600 to-teal-600 hover:from-green-700 hover:to-teal-700 text-white py-2 px-4 rounded-xl"
+                >
+                  Demo Volunteer
+                </Button>
+              </div>
             </div>
           </div>
         </div>

--- a/client/pages/VolunteerDemoDashboard.jsx
+++ b/client/pages/VolunteerDemoDashboard.jsx
@@ -1,0 +1,74 @@
+import Navbar from "../components/Navbar";
+import { WelcomeBanner } from "../components/VolunteerDashboard/WelcomeBanner";
+import { NextEventCard } from "../components/VolunteerDashboard/NextEventCard";
+import { SuggestedEvents } from "../components/VolunteerDashboard/SuggestedEvents";
+import NotificationsPanel from "../components/VolunteerDashboard/NotificationPanel";
+import { CalendarView } from "../components/VolunteerDashboard/Calendar";
+
+const nextEvent = {
+  event_id: 1,
+  event_name: "Park Cleanup",
+  start_time: "2025-06-15T09:00:00",
+  end_time: "2025-06-15T12:00:00",
+  event_location: "Central Park",
+  event_category: "Community",
+  event_description: "Help clean up the park with fellow volunteers.",
+};
+
+const suggestedEvents = [
+  {
+    event_id: 2,
+    event_name: "Food Drive",
+    start_time: "2025-06-20T10:00:00",
+    end_time: "2025-06-20T14:00:00",
+    event_location: "Community Center",
+    event_category: "Charity",
+    event_description: "Sort and pack food donations for families in need.",
+  },
+];
+
+const notifications = [
+  {
+    id: 1,
+    type: "general",
+    message: "Welcome to the demo!",
+    created_at: new Date().toISOString(),
+  },
+];
+
+const calendarInfo = [
+  {
+    event_id: nextEvent.event_id,
+    event_name: nextEvent.event_name,
+    start_time: nextEvent.start_time,
+    end_time: nextEvent.end_time,
+    event_location: nextEvent.event_location,
+  },
+];
+
+export default function VolunteerDemoDashboard() {
+  return (
+    <div className="min-h-screen bg-gray-800 py-12 px-4 text-white">
+      <Navbar />
+      <div className="container mx-auto px-4 py-6">
+        <WelcomeBanner name="Demo Volunteer" />
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mt-8">
+          <div className="lg:col-span-2">
+            <NextEventCard
+              eventName={nextEvent.event_name}
+              date={nextEvent.start_time}
+              time={nextEvent.end_time}
+              location={nextEvent.event_location}
+              category={nextEvent.event_category}
+              eventInfo={nextEvent.event_description}
+              event={nextEvent.event_id}
+            />
+            <SuggestedEvents suggestedEvents={suggestedEvents} />
+            <CalendarView calendarInfo={calendarInfo} />
+          </div>
+          <NotificationsPanel notifications={notifications} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -14,6 +14,8 @@ import ManageUsers from "../pages/ManageUsers.jsx";
 import VolunteerHistoryPage from "../pages/VolunteerHistoryPage.jsx";
 import ScrollToTop from "../components/CompleteProfile/ScrollToTop.jsx";
 import VolunteerDashboard from "../pages/VolunteerDashboard.jsx";
+import AdminDemo from "../pages/AdminDemo.jsx";
+import VolunteerDemoDashboard from "../pages/VolunteerDemoDashboard.jsx";
 import "./index.css";
 
 function RequireAuth({ children, role }) {
@@ -99,6 +101,8 @@ export default function App() {
 
                     {/* dashboard accessible after login */}
                     <Route path="/volunteer-dashboard" element={<VolunteerDashboard />} />
+                    <Route path="/admin-demo" element={<AdminDemo />} />
+                    <Route path="/volunteer-demo" element={<VolunteerDemoDashboard />} />
                 </Routes>
             </Router>
 


### PR DESCRIPTION
## Summary
- add demo admin and volunteer dashboards with static sample data
- add demo login buttons to quickly enter demo dashboards

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a24c16fb088326b56fda410966aca5